### PR TITLE
Cleanup and little fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+# 4 space indentation
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+**/__pycache__
+build

--- a/frodo/demo.py
+++ b/frodo/demo.py
@@ -9,8 +9,11 @@ sentence = 'What cars cost more than $50,000?'
 
 namespace = ''.join([webapp_conf.NS, shortuuid.uuid(sentence)[:8], '/'])
 
-frodo = Frodo(namespace=namespace, fred_uri=webapp_conf.FRED_ENDPOINT)
-
+frodo = Frodo(
+    namespace=namespace,
+    fred_uri=webapp_conf.FRED_ENDPOINT,
+    fred_key=webapp_conf.FRED_KEY
+)
 
 #sentence = 'What are the contaminated sites in the area of Pavia recorded in 2020?'
 #sentence = 'Who well commissioned a cultural property at a certain time?'

--- a/frodo/frodo.py
+++ b/frodo/frodo.py
@@ -500,7 +500,7 @@ class Frodo:
     def get_namespace(self) -> str:
         return self.__ns
 
-    def set_namesapce(self, namespace: str):
+    def set_namespace(self, namespace: str):
         self.__ns = namespace
         
     def generate(self, cq: str, ontology_id: str = None) -> Graph:

--- a/frodo/frodo_webapp.py
+++ b/frodo/frodo_webapp.py
@@ -13,7 +13,12 @@ def index():
         print(text)
         #namespace = ''.join([webapp_conf.NS, shortuuid.uuid(text)[:8], '/'])
         namespace = webapp_conf.NS
-        frodo = Frodo(namespace, webapp_conf.FRED_ENDPOINT)
+
+        frodo = Frodo(
+            namespace=namespace,
+            fred_uri=webapp_conf.FRED_ENDPOINT,
+            fred_key=webapp_conf.FRED_KEY
+        )
         ontology = frodo.generate(text, ontology_id)
         return Response(ontology.serialize(format='text/turtle'),
             mimetype='text/turtle',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup, find_packages
 
 install_requires=[
+   'flask',
    'rdflib',
    'nltk',
+   'shortuuid',
    'fredclient @ git+https://github.com/anuzzolese/fredclient'
 ]
 


### PR DESCRIPTION
This PR adds the `.gitattributes`, `.gitignore` and `.editorconfig` (to be used in combination with the EditorConfig plugin) files.
Moreover, it fixes a typo in the name of a method of the `Frodo` class, it adds two missing dependencies to `setup.py` and it passes the FRED_KEY argument to the `Frodo` class in the demos.